### PR TITLE
Wrap all potentially null attributes in ternary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Manual testing:
 
 ```
 # Replace "xxx" with an actual AWS profile, then execute the integration tests.
-export AWS_PROFILE=xxx 
+export AWS_PROFILE=xxx
 make terraform/pytest PYTEST_ARGS="-v --nomock"
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -2,17 +2,17 @@ module "aggregator" {
   source = "./modules/aggregator"
   count  = var.aggregator != null ? 1 : 0
 
-  name                            = var.aggregator.name
-  account_aggregation_source      = var.aggregator.account_aggregation_source
-  organization_aggregation_source = var.aggregator.organization_aggregation_source
-  tags                            = var.aggregator.tags
+  name                            = var.aggregator != null ? var.aggregator.name : null
+  account_aggregation_source      = var.aggregator != null ? var.aggregator.account_aggregation_source : null
+  organization_aggregation_source = var.aggregator != null ? var.aggregator.organization_aggregation_source : null
+  tags                            = var.aggregator != null ? var.aggregator.tags : null
 }
 
 module "authorization" {
   source = "./modules/authorization"
   count  = var.authorization != null ? 1 : 0
 
-  account_id = var.authorization.account_id
-  region     = var.authorization.region
-  tags       = var.authorization.tags
+  account_id = var.authorization != null ? var.authorization.account_id : null
+  region     = var.authorization != null ? var.authorization.region : null
+  tags       = var.authorization != null ? var.authorization.tags : null
 }


### PR DESCRIPTION
Including this module was making my tflint configuration blow up:
```
Terraform validate with tflint...........................................Failed
- hook id: terraform_tflint
- exit code: 1


ERROR in ././:
Failed to prepare rule checking. An error occurred:

Error: Failed to eval an expression in main.tf:5; Attempt to get attribute from null value: This value is null, so it does not have any attributes.
```

My fix is just to wrap all of the attribute lookups in ternarys. Shouldn't change the logic of evaluation but allows verification to pass.